### PR TITLE
Fix failing test

### DIFF
--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -6,8 +6,7 @@ test_that("unselect_", {
   library(taxstats)
   library(dplyr)
   y <- sample_file_1314 %>% copy %>% unselect_(.dots = "Sw_amt")
-  z <- sample_file_1314 %>% copy %>% select(-Sw_amt)
-  expect_equal(y, z)
+  expect_false("Sw_amt" %in% names(y))
 })
 
 test_that("as.numeric_unless_warning", {


### PR DESCRIPTION
In the next version of dtplyr, select automatically converts to a lazy_dt so this test no longer works. I don't really understand the point of this test since unselect_ is just a wrapper around hutils::drop_cols, so I just verified that the columns are dropped as expected.